### PR TITLE
Add Android login project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# fi-an-test
+# Android ChatGPT Clone
+
+This is a minimal Android project skeleton demonstrating a login screen that communicates with an existing backend.
+
+## Login Logic
+The login implementation calls `https://auth.ai.fourmix.co.jp/api/v1/auth/login` with Retrofit. On success, the main activity is displayed. See `LoginActivity.kt` for details.
+
+## Build
+This project uses Gradle. In a real environment you would run `./gradlew assembleDebug` to build.
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.chatgptclone'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId 'com.example.chatgptclone'
+        minSdk 24
+        targetSdk 33
+        versionCode 1
+        versionName '1.0'
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules placeholder

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.chatgptclone">
+
+    <application
+        android:allowBackup="true"
+        android:label="ChatGPTClone"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ChatGPTClone">
+        <activity android:name=".LoginActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:name=".MainActivity" />
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/chatgptclone/LoginActivity.kt
+++ b/app/src/main/java/com/example/chatgptclone/LoginActivity.kt
@@ -1,0 +1,53 @@
+package com.example.chatgptclone
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.example.chatgptclone.api.AuthService
+import com.example.chatgptclone.api.ApiClient
+import com.example.chatgptclone.models.LoginRequest
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class LoginActivity : AppCompatActivity() {
+
+    private lateinit var emailEditText: EditText
+    private lateinit var passwordEditText: EditText
+    private lateinit var loginButton: Button
+    private val service: AuthService by lazy { ApiClient.authService }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_login)
+
+        emailEditText = findViewById(R.id.emailEditText)
+        passwordEditText = findViewById(R.id.passwordEditText)
+        loginButton = findViewById(R.id.loginButton)
+
+        loginButton.setOnClickListener { attemptLogin() }
+    }
+
+    private fun attemptLogin() {
+        val email = emailEditText.text.toString()
+        val password = passwordEditText.text.toString()
+
+        val request = LoginRequest(email, password, "", "")
+        service.login(request).enqueue(object : Callback<Unit> {
+            override fun onResponse(call: Call<Unit>, response: Response<Unit>) {
+                if (response.isSuccessful) {
+                    startActivity(Intent(this@LoginActivity, MainActivity::class.java))
+                } else {
+                    Toast.makeText(this@LoginActivity, "Login failed", Toast.LENGTH_SHORT).show()
+                }
+            }
+
+            override fun onFailure(call: Call<Unit>, t: Throwable) {
+                Toast.makeText(this@LoginActivity, t.localizedMessage, Toast.LENGTH_SHORT).show()
+            }
+        })
+    }
+}

--- a/app/src/main/java/com/example/chatgptclone/MainActivity.kt
+++ b/app/src/main/java/com/example/chatgptclone/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.example.chatgptclone
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/app/src/main/java/com/example/chatgptclone/api/ApiClient.kt
+++ b/app/src/main/java/com/example/chatgptclone/api/ApiClient.kt
@@ -1,0 +1,16 @@
+package com.example.chatgptclone.api
+
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object ApiClient {
+    private const val BASE_URL = "https://auth.ai.fourmix.co.jp/api/v1/"
+
+    val authService: AuthService by lazy {
+        val retrofit = Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+        retrofit.create(AuthService::class.java)
+    }
+}

--- a/app/src/main/java/com/example/chatgptclone/api/AuthService.kt
+++ b/app/src/main/java/com/example/chatgptclone/api/AuthService.kt
@@ -1,0 +1,11 @@
+package com.example.chatgptclone.api
+
+import com.example.chatgptclone.models.LoginRequest
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthService {
+    @POST("auth/login")
+    fun login(@Body request: LoginRequest): Call<Unit>
+}

--- a/app/src/main/java/com/example/chatgptclone/models/LoginRequest.kt
+++ b/app/src/main/java/com/example/chatgptclone/models/LoginRequest.kt
@@ -1,0 +1,8 @@
+package com.example.chatgptclone.models
+
+data class LoginRequest(
+    val email: String,
+    val password: String,
+    val opt: String,
+    val tenant: String
+)

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/emailEditText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Email"
+        android:inputType="textEmailAddress"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_margin="16dp" />
+
+    <EditText
+        android:id="@+id/passwordEditText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Password"
+        android:inputType="textPassword"
+        app:layout_constraintTop_toBottomOf="@id/emailEditText"
+        app:layout_constraintStart_toStartOf="@id/emailEditText"
+        app:layout_constraintEnd_toEndOf="@id/emailEditText"
+        android:layout_margin="16dp" />
+
+    <Button
+        android:id="@+id/loginButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Login"
+        app:layout_constraintTop_toBottomOf="@id/passwordEditText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Main chat UI placeholder -->
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">ChatGPTClone</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.ChatGPTClone" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/teal_200</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
+    }
+}
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,3 @@
+# placeholder properties for gradle wrapper
+# specify distribution url and other settings
+# customize as needed

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Placeholder gradlew script
+exit 0

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Placeholder gradlew.bat script
+exit /B 0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "ChatGPTClone"
+include(":app")


### PR DESCRIPTION
## Summary
- create Gradle-based Android project skeleton
- implement login screen calling `auth/login` endpoint with Retrofit
- add minimal resources and main activity

## Testing
- `./gradlew test` *(fails: no tasks run)*

------
https://chatgpt.com/codex/tasks/task_e_684c2f9cff2483319b3dff79f09ce0cc